### PR TITLE
Cleanup: remove unused functions and variables

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -54,7 +54,6 @@ use crate::{
 
 pub enum InputMode {
     Normal,
-    Editing,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -120,8 +119,8 @@ impl App {
         let tick = self.config.tick_gap.clone();
         thread::spawn(move || loop {
             thread::sleep(tick);
-            sd.send(EventType::Player);
-            sd.send(EventType::Radio);
+            sd.send(EventType::Player).unwrap();
+            sd.send(EventType::Radio).unwrap();
         });
         // start event
         loop {
@@ -136,8 +135,7 @@ impl App {
                             code => {
                                 handle_keyboard_event(self, code);
                             }
-                        },
-                        InputMode::Editing => {}
+                        }
                     }
                 }
             }
@@ -186,7 +184,7 @@ impl App {
             match route {
                 Routes::Main => {
                     self.draw_header(frame, chunks[0]);
-                    self.draw_body(frame, chunks[1]);
+                    self.draw_body(frame, chunks[1]).unwrap();
                 }
                 Routes::Help => {
                     self.draw_header(frame, chunks[0]);

--- a/src/handler/fs.rs
+++ b/src/handler/fs.rs
@@ -39,7 +39,7 @@ fn add_media_to_player(app: &mut App, once: bool) -> bool {
             match selected {
                 0 => match dir.parent() {
                     Some(dir) => {
-                        set_current_dir(dir);
+                        set_current_dir(dir).unwrap();
                         fse.current_path = dir.to_string_lossy().to_string();
                         fse.index.select(Some(0));
                     }
@@ -51,7 +51,7 @@ fn add_media_to_player(app: &mut App, once: bool) -> bool {
                     let dir_entry = &fse.dirs[num - 1];
                     let path = dir_entry.path();
                     fse.current_path = String::from(path.to_string_lossy());
-                    set_current_dir(path);
+                    set_current_dir(path).unwrap();
                     fse.index.select(Some(0));
                 }
             }
@@ -87,7 +87,6 @@ fn add_media_to_player(app: &mut App, once: bool) -> bool {
             }
             return res;
         }
-        return true;
     } else {
         fse.index.select(Some(0));
         return false;

--- a/src/handler/help.rs
+++ b/src/handler/help.rs
@@ -22,13 +22,13 @@ use crate::app::App;
 pub fn handle_help(app: &mut App, code: KeyCode) -> bool {
     match code {
         KeyCode::Enter => {
-            open::that(app.config.home_page);
+            open::that(app.config.home_page).unwrap();
             return true;
         }
         KeyCode::Char('r') => {
             let mut config_dir = dirs::config_dir().unwrap();
             config_dir.push("RustPlayer");
-            open::that(config_dir);
+            open::that(config_dir).unwrap();
             return true;
         }
         _ => {

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -69,7 +69,7 @@ pub fn handle_routes(app: &mut App, key: KeyCode) -> bool {
 }
 
 pub fn handle_keyboard_event(app: &mut App, key: KeyCode) {
-    let mut flag = false;
+    let mut flag;
     let top_route = app.route_stack.last().unwrap();
 
     match top_route {

--- a/src/handler/player.rs
+++ b/src/handler/player.rs
@@ -27,7 +27,7 @@ pub fn handle_player(app: &mut App, code: KeyCode) -> bool {
             app.player.set_volume(new_volume);
             return true;
         }
-        KeyCode::Char('=') => {
+        KeyCode::Char('=') | KeyCode::Char('+') => {
             let volume = app.player.volume() + 0.05;
             let new_volume = volume.min(1.0);
             app.player.set_volume(new_volume);
@@ -47,7 +47,7 @@ pub fn handle_radio(app: &mut App, code: KeyCode) -> bool {
             app.radio.set_volume(new_volume);
             return true;
         }
-        KeyCode::Char('=') => {
+        KeyCode::Char('=') | KeyCode::Char('+') => {
             let volume = app.radio.volume() + 0.05;
             let new_volume = volume.min(1.0);
             app.radio.set_volume(new_volume);

--- a/src/media/media.rs
+++ b/src/media/media.rs
@@ -17,8 +17,8 @@
 
 use crate::ui::radio::RadioConfig;
 
+
 pub enum Source {
-    Http(String),
     M3u8(RadioConfig),
     Local(String),
 }

--- a/src/media/player.rs
+++ b/src/media/player.rs
@@ -142,7 +142,6 @@ impl Player for MusicPlayer {
 
     fn add_to_list(&mut self, media: Media, once: bool) -> bool {
         match media.src {
-            super::media::Source::Http(_) => false,
             super::media::Source::Local(path) => {
                 return self.play_with_file(path, once);
             }
@@ -394,6 +393,7 @@ pub struct RadioItem {
     url: String,
 }
 
+#[allow(dead_code)]
 pub struct RadioPlayer {
     pub item: Option<RadioItem>,
     pub list: Vec<PlayListItem>,
@@ -433,7 +433,6 @@ impl Player for RadioPlayer {
         self.last_playing_id = -1;
         let src = media.src;
         match src {
-            super::media::Source::Http(_) => false,
             super::media::Source::M3u8(url) => {
                 let (tx, rx) = channel();
                 let m3u8_url = url.url.clone();

--- a/src/ui/fs.rs
+++ b/src/ui/fs.rs
@@ -32,6 +32,7 @@ use tui::Frame;
 use crate::app::ActiveModules;
 use crate::App;
 
+#[allow(dead_code)]
 pub struct FsExplorer {
     pub current_path: String,
     pub files: Vec<DirEntry>,

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -25,7 +25,7 @@ use tui::{
     Frame,
 };
 
-use crate::{app::App, media::player::Player};
+use crate::app::App;
 
 pub fn draw_help<B>(_app: &mut App, frame: &mut Frame<B>, area: Rect)
 where

--- a/src/ui/music_board.rs
+++ b/src/ui/music_board.rs
@@ -68,7 +68,7 @@ where
         .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
         .split(area);
 
-    let mut playing_text = "".to_string();
+    let playing_text;
     if let Some(item) = player.playing_song() {
         playing_text = String::from(item.name.as_str());
     } else {

--- a/src/util/lyrics.rs
+++ b/src/util/lyrics.rs
@@ -55,7 +55,7 @@ impl Lyrics {
         let mut buffer = vec![];
         let regex =
             Regex::new(r"\[(?P<min>\d+):(?P<sec>\d+).(?P<ms>\d+)](?P<content>[^\[\]]*)").unwrap();
-        f.read_to_end(&mut buffer);
+        f.read_to_end(&mut buffer).unwrap();
         let m = String::from_utf8(buffer).unwrap();
         let mut lyrics_vec = vec![];
         for cap in regex.captures_iter(m.as_str()) {
@@ -71,6 +71,7 @@ impl Lyrics {
         Self { list: lyrics_vec }
     }
 
+    #[allow(dead_code)]
     pub fn count(&self) -> usize {
         self.list.len()
     }

--- a/src/util/m3u8.rs
+++ b/src/util/m3u8.rs
@@ -33,7 +33,7 @@ pub fn empty_cache() {
         if let Ok(dirs) = it {
             for dir in dirs {
                 if let Ok(d) = dir {
-                    std::fs::remove_file(d.path());
+                    std::fs::remove_file(d.path()).unwrap();
                 }
             }
         }

--- a/tests/m3u8.rs
+++ b/tests/m3u8.rs
@@ -8,7 +8,7 @@ fn fetch_and_play() {
     let src = "http://ngcdn002.cnr.cn/live/jjzs/index.m3u8";
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
-        download(&src.to_owned(), &tx);
+        download(&src.to_owned(), &tx).unwrap();
     });
     match rx.recv_timeout(Duration::from_secs(5)) {
         Ok(s) => {


### PR DESCRIPTION
There are quite a several unused functions, variables, and deps. This PR cleans up this stuff.

Full log
```
mod.rs - don't set flag value to false, as it's not being used before it gets overwritten by handle_active_modules
player.rs - member stream never was read, even though it's still can be useful, maybe if you implement it in the future(?)
fs.rs - handler error on set_current_dir function, and removed unreachable "return" value (boolean)
help.rs - removed unused media::player::Player dependency
player.rs - "+" key char from numeric keypad
player.rs - allow stream, stream_handle members
music_board.rs - don't explicitly assign empty string
lyrics.rs - handle error on read_to_end function and allow count function (used in testing)
m3u8.rs - handle error on remove_file & download function
app.rs - handle error on sd.send function
```
The log isn't any good but in the limited time, I was only able to make this small note.

Also `Http(String)` member has been removed in this PR since they're not implemented but please hit me up if you would implement them in the future, so I'll revert that part. `on_error_msg_callback` member was also never read but I noticed it's been used as a callback in `app.rs` when an error occurred so I kept it untouched for now, practically `expect` also a good idea to use instead callback but the log will not be directed.